### PR TITLE
add moveToFirst before accessing cursor

### DIFF
--- a/app/src/main/java/com/ar/bootcampar/model/Database.java
+++ b/app/src/main/java/com/ar/bootcampar/model/Database.java
@@ -677,6 +677,7 @@ public class Database extends SQLiteOpenHelper implements IDatabase {
                 return null;
             }
             else if (cursor.getCount() == 1) {
+                cursor.moveToFirst();
                 return creator.apply(cursor);
             }
 
@@ -703,6 +704,7 @@ public class Database extends SQLiteOpenHelper implements IDatabase {
                     ColumnaId + "=?", new String[] { Long.toString(id) },
                     null, null, null);
             if (cursor.getCount() == 1) {
+                cursor.moveToFirst();
                 return creador.apply(cursor);
             }
 


### PR DESCRIPTION
Agregar el moveToFirst antes de acceder a los campos del cursor, no se está pudiendo registrar cuentas en este momento porque el cursor está en la posición -1 y explota.