### PR TITLE
do not disable edittext to update value

### DIFF
--- a/app/src/main/java/com/ar/bootcampar/fragments/ContactFragment.java
+++ b/app/src/main/java/com/ar/bootcampar/fragments/ContactFragment.java
@@ -80,11 +80,9 @@ public class ContactFragment extends Fragment {
         if (usuario != null) {
             EditText editText = ((EditText)getView().findViewById(R.id.editContactFirstName));
             editText.setText(usuario.getNombre());
-            editText.setEnabled(false);
 
             editText = ((EditText)getView().findViewById(R.id.editContactEmailAddress));
             editText.setText(usuario.getEmail());
-            editText.setEnabled(false);
 
             editText = ((EditText)getView().findViewById(R.id.editContactPhoneNumber));
             editText.setText(usuario.getTelefono());


### PR DESCRIPTION
Al deshabilitar la edición de nombre y email del formulario de contacto no se refrescan los cambios si se modifican en el perfil así que lo vuelvo a habilitar.