### PR TITLE
fix course list refreshing

### DIFF
--- a/app/src/main/java/com/ar/bootcampar/fragments/CourseListFragment.java
+++ b/app/src/main/java/com/ar/bootcampar/fragments/CourseListFragment.java
@@ -119,4 +119,13 @@ public class CourseListFragment extends Fragment {
         }
     }
 
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        LogicServices logicServices = new LogicServices(getContext());
+        List<Curso> listaCursos = logicServices.listarCursos();
+        listaInscripciones = logicServices.buscarInscripciones(usuario);
+        adapter.cambiarCursos(listaCursos, listaInscripciones);
+    }
 }


### PR DESCRIPTION
Si desde la lista de cursos uno se inscribe a un curso y se vuelve a la lista de cursos no aparece el corazón de favorito porque no se refresca la lista y lo toma como si todavía estuviese no inscripto. Con esto se arregla.