### PR TITLE
fix inscription rating refresh

### DIFF
--- a/app/src/main/java/com/ar/bootcampar/activities/CourseDetailActivity.java
+++ b/app/src/main/java/com/ar/bootcampar/activities/CourseDetailActivity.java
@@ -69,8 +69,7 @@ public class CourseDetailActivity extends AppCompatActivity {
             }
 
             enroll.setOnClickListener(v -> {
-                Inscripcion inscripcionActual = inscripcion;
-
+                Inscripcion inscripcionActual = logicServices.buscarInscripcion(usuario, curso);
                 if (inscripcionActual == null) {
                     Tupla<Inscripcion, String> resultado = logicServices.inscribirCurso(usuario, curso);
                     Toast.makeText(CourseDetailActivity.this, resultado.derecha, Toast.LENGTH_SHORT).show();


### PR DESCRIPTION
En la actividad de detalle del curso se le asigna una closure al botón de inscribirse, Java atrapa el valor de la variable inscripcion por lo que al entrar al video, cambiar el valor de la puntuación, volver a la actividad de detalle y volver al listado de videos vuelve a enviarle la inscripción original con la calificación antigua. Lo cambié para que haga el query a base de datos, suficiente para que funcione.